### PR TITLE
Fixup for Makefile merge 9466e57ce8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ CARAVEL_LITE?=1
 ifeq ($(CARAVEL_LITE),1) 
 	CARAVEL_NAME := caravel-lite
 	CARAVEL_REPO := https://github.com/efabless/caravel-lite 
-	CARAVEL_COMMIT := main
+	CARAVEL_BRANCH := main
 else
 	CARAVEL_NAME := caravel
 	CARAVEL_REPO := https://github.com/efabless/caravel 
-	CARAVEL_COMMIT := master
+	CARAVEL_BRANCH := master
 endif
 
 # Install caravel as submodule, (1): submodule, (0): clone
@@ -79,12 +79,12 @@ ifeq ($(SUBMODULE),1)
 	$(eval CARAVEL_PATH := $(shell realpath --relative-to=$(shell pwd) $(CARAVEL_ROOT)))
 	@if [ ! -d $(CARAVEL_ROOT) ]; then git submodule add --name $(CARAVEL_NAME) $(CARAVEL_REPO) $(CARAVEL_PATH); fi
 	@git submodule update --init
-	@cd $(CARAVEL_ROOT); git checkout $(CARAVEL_COMMIT)
+	@cd $(CARAVEL_ROOT); git checkout $(CARAVEL_BRANCH)
 	$(MAKE) simlink
 else
 	@echo "Installing $(CARAVEL_NAME).."
 	@git clone $(CARAVEL_REPO) $(CARAVEL_ROOT)
-	@cd $(CARAVEL_ROOT); git checkout $(CARAVEL_COMMIT)
+	@cd $(CARAVEL_ROOT); git checkout $(CARAVEL_BRANCH)
 endif
 
 # Create symbolic links to caravel's main files


### PR DESCRIPTION
@Manarabdelaty it looks like during one of the merges some of your changes to the Makefile were lost. It looks like you settled on `CARAVEL_BRANCH` as the variable name. My fixup commit 3c8cb857287c0d7 was not aware of that and continued to use `CARAVEL_COMMIT` in multiple places since we were in different branches. Hopefully this PR gets this variable all on the right page.