### PR TITLE
Makefile and README fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ CARAVEL_LITE?=1
 ifeq ($(CARAVEL_LITE),1) 
 	CARAVEL_NAME := caravel-lite
 	CARAVEL_REPO := https://github.com/efabless/caravel-lite 
-	CARAVEL_TAG := 'rc-8'
+	CARAVEL_TAG := 'mpw-3'
 else
 	CARAVEL_NAME := caravel
 	CARAVEL_REPO := https://github.com/efabless/caravel 
-	CARAVEL_TAG := 'rc-8'
+	CARAVEL_TAG := 'mpw-4b'
 endif
 
 
@@ -118,7 +118,7 @@ run-precheck: check-precheck check-pdk check-caravel
 # Install PDK using OL's Docker Image
 .PHONY: pdk-nonnative
 pdk-nonnative: skywater-pdk skywater-library skywater-timing open_pdks
-	docker run --rm -v $(PDK_ROOT):$(PDK_ROOT) -v $(CARAVEL_ROOT):$(CARAVEL_ROOT) -e CARAVEL_ROOT=$(CARAVEL_ROOT) -e PDK_ROOT=$(PDK_ROOT) -u $(shell id -u $(USER)):$(shell id -g $(USER)) efabless/openlane:current sh -c "cd $(CARAVEL_ROOT); make build-pdk; make gen-sources"
+	docker run --rm -v $(PDK_ROOT):$(PDK_ROOT) -v $(CARAVEL_ROOT):$(CARAVEL_ROOT) -e CARAVEL_ROOT=$(CARAVEL_ROOT) -e PDK_ROOT=$(PDK_ROOT) -u $(shell id -u $(USER)):$(shell id -g $(USER)) efabless/openlane:2021.09.19_20.25.16 sh -c "cd $(CARAVEL_ROOT); make build-pdk; make gen-sources"
 
 # Clean 
 .PHONY: clean

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,15 +63,14 @@ Install Caravel
 To setup caravel, run the following:
 
 .. code:: bash
-
-    # If unset, CARAVEL_ROOT will be set to $(pwd)/caravel
-    # If you want to install caravel at a different location, run "export CARAVEL_ROOT=<caravel-path>"
-    export CARAVEL_ROOT=$(pwd)/caravel
-
-    # Disable submodule installation if needed by, run "export SUBMODULE=0"
     
     git clone https://github.com/efabless/caravel_user_project.git
     cd caravel_user_project
+    
+    # If unset, CARAVEL_ROOT will be set to $(pwd)/caravel
+    # If you want to install caravel at a different location, run "export CARAVEL_ROOT=<caravel-path>"
+    export CARAVEL_ROOT=$(pwd)/caravel
+    
     make install
 
 To update the installed caravel to the latest, run:
@@ -110,7 +109,7 @@ corresponding files:
 -  `Openlane Makefile <../../openlane/Makefile>`__: This provides an easier
    way for running openlane to harden your macros. Refer to `Hardening
    the User Project Macro using
-   Openlane <#hardening-the-user-project-macro-using-openlane>`__. Also,
+   Openlane <#hardening-the-user-project-using-openlane>`__. Also,
    the makefile retains the openlane summary reports under the signoff
    directory.
 
@@ -266,10 +265,7 @@ Your hardened ``user_project_wrapper`` must match the `golden user_project_wrapp
    <img src="./_static/empty.png" width="40%" height="40%">
    </p>
  
-
-These fixed configurations are specified `here <https://github.com/efabless/caravel/blob/master/openlane/user_project_wrapper_empty/fixed_wrapper_cfgs.tcl>`__ .
-
-However, you are allowed to change the following if you need to: 
+You are allowed to change the following if you need to: 
 
 - PDN Vertical and Horizontal Pitch & Offset
 


### PR DESCRIPTION
Fixed Makefile caravel and caravel-lite tags to point at the latest tags
Fixed the openlane image name for `pdk_nonnative` to run the correct docker image
README modifications, including removing broken link