### PR TITLE
Added the production dockerfile and OS requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN git clone https://github.com/riscv/riscv-gnu-toolchain ${RISCV_TOOLCHAIN_DOW
     make -j $(nproc) && \
     rm -rf ${RISCV_TOOLCHAIN_DOWNLOAD_DIR}
 ENV PATH=${RISCV_TOOLCHAIN_INSTALL_DIR}/bin:${PATH}
+ENV GCC_PATH=${RISCV_TOOLCHAIN_INSTALL_DIR}/bin
 
 # Build Magic VLSI
 ENV MAGIC_VLSI_DOWNLOAD_DIR=/tmp/magic_vlsi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+ARG BASE_IMAGE=ubuntu:20.04
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY ./apt_requirements.txt /tmp/apt_requirements.txt
+
+RUN apt update && \
+    apt install -y $(grep -v "^#" /tmp/apt_requirements.txt)
+
+# Build RISCV toolchain
+ENV RISCV_TOOLCHAIN_DOWNLOAD_DIR=/tmp/riscv-gnu-toolchain
+ENV RISCV_TOOLCHAIN_INSTALL_DIR=/opt/riscv_toolchain
+RUN git clone https://github.com/riscv/riscv-gnu-toolchain ${RISCV_TOOLCHAIN_DOWNLOAD_DIR} && \
+    cd ${RISCV_TOOLCHAIN_DOWNLOAD_DIR} && \
+    ./configure \
+    --prefix=${RISCV_TOOLCHAIN_INSTALL_DIR} \
+    --with-arch=rv32imc \
+    --with-abi=ilp32 && \
+    make -j $(nproc) && \
+    rm -rf ${RISCV_TOOLCHAIN_DOWNLOAD_DIR}
+ENV PATH=${RISCV_TOOLCHAIN_INSTALL_DIR}/bin:${PATH}
+
+# Build Magic VLSI
+ENV MAGIC_VLSI_DOWNLOAD_DIR=/tmp/magic_vlsi
+ENV MAGIC_VLSI_INSTALL_DIR=/opt/magic_vlsi
+RUN git clone https://github.com/RTimothyEdwards/magic.git ${MAGIC_VLSI_DOWNLOAD_DIR} && \
+    cd ${MAGIC_VLSI_DOWNLOAD_DIR} && \
+    ./configure --prefix=${MAGIC_VLSI_INSTALL_DIR} --without-x && \
+    make && \
+    make install && \
+    rm -rf ${MAGIC_VLSI_DOWNLOAD_DIR}
+ENV PATH=${MAGIC_VLSI_INSTALL_DIR}/bin:${PATH}
+
+# Build the PDKS with sram
+# This copy should be removed in the future and volumes should be preferred
+COPY . /caravel_user_project
+ENV PDK_ROOT=/tmp/pdks
+WORKDIR /caravel_user_project
+RUN make install && \
+    make install_mcw && \
+    make pdk-with-sram

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ ENV PATH=${MAGIC_VLSI_INSTALL_DIR}/bin:${PATH}
 
 # Build the PDKS with sram
 # This copy should be removed in the future and volumes should be preferred
-COPY . /caravel_user_project
+ARG CARAVEL_BUILD_DIRECTORY=/tmp/caravel_user_project
+COPY . ${CARAVEL_BUILD_DIRECTORY}
 ENV PDK_ROOT=/tmp/pdks
-WORKDIR /caravel_user_project
+WORKDIR ${CARAVEL_BUILD_DIRECTORY}
 RUN make install && \
     make install_mcw && \
-    make pdk-with-sram
+    make pdk-with-sram && \
+    rm -rf ${CARAVEL_BUILD_DIRECTORY}

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,20 @@ SIM ?= RTL
 # Install lite version of caravel, (1): caravel-lite, (0): caravel
 CARAVEL_LITE?=1
 
-ifeq ($(CARAVEL_LITE),1) 
+ifeq ($(CARAVEL_LITE),1)
 	CARAVEL_NAME := caravel-lite
-	CARAVEL_REPO := https://github.com/efabless/caravel-lite 
+	CARAVEL_REPO := https://github.com/efabless/caravel-lite
 	CARAVEL_TAG := 'mpw-5a'
 else
 	CARAVEL_NAME := caravel
-	CARAVEL_REPO := https://github.com/efabless/caravel 
+	CARAVEL_REPO := https://github.com/efabless/caravel
 	CARAVEL_TAG := 'mpw-5a'
 endif
 
 
 # Include Caravel Makefile Targets
 .PHONY: % : check-caravel
-%: 
+%:
 	export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
 
 # Verify Target for running simulations
@@ -53,14 +53,9 @@ PATTERNS=$(shell cd verilog/dv && find * -maxdepth 0 -type d)
 DV_PATTERNS = $(foreach dv, $(PATTERNS), verify-$(dv))
 TARGET_PATH=$(shell pwd)
 VERIFY_COMMAND="cd ${TARGET_PATH}/verilog/dv/$* && export SIM=${SIM} && make"
-$(DV_PATTERNS): verify-% : ./verilog/dv/% 
-	docker run -v ${TARGET_PATH}:${TARGET_PATH} -v ${PDK_ROOT}:${PDK_ROOT} \
-                -v ${CARAVEL_ROOT}:${CARAVEL_ROOT} \
-                -e TARGET_PATH=${TARGET_PATH} -e PDK_ROOT=${PDK_ROOT} \
-                -e CARAVEL_ROOT=${CARAVEL_ROOT} \
-                -u $(id -u $$USER):$(id -g $$USER) efabless/dv_setup:latest \
-                sh -c $(VERIFY_COMMAND)
-				
+$(DV_PATTERNS): verify-% : ./verilog/dv/%
+	sh -c $(VERIFY_COMMAND)
+
 # Openlane Makefile Targets
 BLOCKS = $(shell cd openlane && find * -maxdepth 0 -type d)
 .PHONY: $(BLOCKS)
@@ -76,7 +71,7 @@ install:
 # Create symbolic links to caravel's main files
 .PHONY: simlink
 simlink: check-caravel
-### Symbolic links relative path to $CARAVEL_ROOT 
+### Symbolic links relative path to $CARAVEL_ROOT
 	$(eval MAKEFILE_PATH := $(shell realpath --relative-to=openlane $(CARAVEL_ROOT)/openlane/Makefile))
 	$(eval PIN_CFG_PATH  := $(shell realpath --relative-to=openlane/user_project_wrapper $(CARAVEL_ROOT)/openlane/user_project_wrapper_empty/pin_order.cfg))
 	mkdir -p openlane
@@ -93,12 +88,12 @@ update_caravel: check-caravel
 
 # Uninstall Caravel
 .PHONY: uninstall
-uninstall: 
+uninstall:
 	rm -rf $(CARAVEL_ROOT)
 
 # Install Openlane
 .PHONY: openlane
-openlane: 
+openlane:
 	cd openlane && $(MAKE) openlane
 
 # Install Pre-check
@@ -115,7 +110,7 @@ run-precheck: check-pdk check-precheck
 	docker run -v $(PRECHECK_ROOT):$(PRECHECK_ROOT) -v $(INPUT_DIRECTORY):$(INPUT_DIRECTORY) -v $(PDK_ROOT):$(PDK_ROOT) -e INPUT_DIRECTORY=$(INPUT_DIRECTORY) -e PDK_ROOT=$(PDK_ROOT) \
 	-u $(shell id -u $(USER)):$(shell id -g $(USER)) efabless/mpw_precheck:latest bash -c "cd $(PRECHECK_ROOT) ; python3 mpw_precheck.py --input_directory $(INPUT_DIRECTORY) --pdk_root $(PDK_ROOT)"
 
-# Clean 
+# Clean
 .PHONY: clean
 clean:
 	cd ./verilog/dv/ && \
@@ -141,5 +136,5 @@ check-pdk:
 
 .PHONY: help
 help:
-	cd $(CARAVEL_ROOT) && $(MAKE) help 
+	cd $(CARAVEL_ROOT) && $(MAKE) help
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'

--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -1,0 +1,38 @@
+# This file specifies all OS requirements
+
+# Development tools
+bash-completion
+git
+
+# RISCV toolchain build requirements
+autoconf
+automake
+autotools-dev
+bc
+bison
+build-essential
+curl
+flex
+gawk
+git
+gperf
+libexpat-dev
+libgmp-dev
+libmpc-dev
+libmpfr-dev
+libtool
+patchutils
+python3
+texinfo
+zlib1g-dev
+
+# Magic VLSI requirements
+tcl-dev
+tk-dev
+csh
+libglu1-mesa-dev
+libcairo2-dev
+
+# Caravel requirements
+iverilog
+wget


### PR DESCRIPTION
The dockerfile in the root of the repo contains all tools required to develop on the repo. This initial attempt is probably missing a large number of necessary things (I've created it from the perspective that I've had with the repo) so feel free to comment and add more.

To use the image run `docker build . -t "whatever tag you want"` from the root of the repo and then `docker run -it "whatever tag you want" -v ./:/caravel_user_project`  and then you should be able to run the standard commands like `make verify-` etc...

Eventually I think it would be good to have each of the tools having their own dockerfiles that they push so there's already an image available for the right version and this repo pulls in those images using [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/), copying only the necessary files.

I think this would be a positive change because it guaruntees a consistent and reproducible environment for all users and developers, making issues occur more infrequently and making them easier to debug when they do pop up. This change does not affect users immediately since they do not have to use the docker container, but when it is mature enough (maybe in the next shuttle) it can be adopted more readily by users.

Happy to take criticism or comments and thank you for the consideration