### PR TITLE
Use current version of mpw_precheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ export SKYWATER_COMMIT=c094b6e83a4f9298e47f696ec5a7fd53535ec5eb
 export OPEN_PDKS_COMMIT=7519dfb04400f224f140749cda44ee7de6f5e095
 export PDK_MAGIC_COMMIT=7d601628e4e05fd17fcb80c3552dacb64e9f6e7b
 export OPENLANE_TAG=2022.02.23_02.50.41
+export PRECHECK_COMMIT=b30e779ab0ff90e37e5c56795066a30804816e13
 
 # Install lite version of caravel, (1): caravel-lite, (0): caravel
 CARAVEL_LITE?=1
@@ -165,7 +166,8 @@ uninstall:
 # Default installs to the user home directory, override by "export PRECHECK_ROOT=<precheck-installation-path>"
 .PHONY: precheck
 precheck:
-	@git clone --depth=1 --branch mpw-5a https://github.com/efabless/mpw_precheck.git $(PRECHECK_ROOT)
+	@git clone --depth=1 https://github.com/efabless/mpw_precheck.git $(PRECHECK_ROOT)
+	cd $(PRECHECK_ROOT); git checkout -qf $(PRECHECK_COMMIT)
 	@docker pull efabless/mpw_precheck:latest
 
 .PHONY: run-precheck


### PR DESCRIPTION
Previously, the Makefile referenced the mpw-5a version of mpw_precheck. It detects DRC violations on designs employing OpenSRAM macros. The latest version of the mpw_precheck tools does not report these DRC violations, so it makes sense to upgrade to using those.

Since the currently latest version does not have a tag (I think), a specific commit (suggested on the openlane slack channel by Matt Venn) is referenced instead. A variable for this commit has been added next to the other variables referencing specific commits of other repositories.