### PR TITLE
Fix warning: undefined variable 'PWD'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 MAKEFLAGS+=--warn-undefined-variables
 
+PWD?=$(shell pwd)
 CARAVEL_ROOT?=$(PWD)/caravel
 PRECHECK_ROOT?=${HOME}/mpw_precheck
 MCW_ROOT?=$(PWD)/mgmt_core_wrapper


### PR DESCRIPTION
Running make setup was showing that PWD is undefined, which was making openlane setup fail. Fixable by defining PWD from bash, or use a new variable to avoid confusion with the env variable $PWD