### PR TITLE
change OPENLANE_ROOT in the quick start guide

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -70,7 +70,7 @@ Starting your project
     
     	# make sure to change <directory_name> with the directory you created in step 2
 	# in this case it is caravel_tutorial
-	export OPENLANE_ROOT=~/<directory_name>/openlane # you need to export this whenever you start a new shell
+	export OPENLANE_ROOT=~/<directory_name>/openlane_src # you need to export this whenever you start a new shell
 	
 	export PDK_ROOT=~/<directory_name>/pdks # you need to export this whenever you start a new shell
 


### PR DESCRIPTION
change `OPENLANE_ROOT` dirname to openlane_src to avoid conflict with openlane config folder