### PR TITLE
docs: fix intrapage link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -119,7 +119,7 @@ Starting your project
 		make <module_name>	
 	..
 
-		For an example of hardening a project please refer to `user_project_example <https://github.com/efabless/caravel_user_project/blob/main/docs/source/index.rst#hardening-the-user-project-using-openlane>`_
+		For an example of hardening a project please refer to :ref:`Hardening the User Project using OpenLane`.
 	
 #.  Integrate modules into the user_project_wrapper
 


### PR DESCRIPTION
Without this, the link redirect to a GitHub .rst doc preview instead of linking to the same readthedocs page.
