### PR TITLE
changed 130B to 130A

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,7 +93,7 @@ Starting your project
 	# export the PDK variant depending on your shuttle, if you don't know leave it to the default
 	
 	# for sky130 MPW shuttles....
-	export PDK=sky130B
+	export PDK=sky130A
 	
 	# for the gf180 GFMPW shuttles...
 	export PDK=gf180mcuC


### PR DESCRIPTION
I've been told that MPW-7, as well as MPW-8, are now going to use sky130A instead of sky130B. Kindly update it in quickstart to avoid confusion.