### PR TITLE
fixed defines.v path and CLOCK_PERIOD

### DIFF
--- a/openlane/user_proj_example/config.tcl
+++ b/openlane/user_proj_example/config.tcl
@@ -19,7 +19,7 @@ set ::env(STD_CELL_LIBRARY) "gf180mcu_fd_sc_mcu7t5v0"
 set ::env(DESIGN_NAME) user_proj_example
 
 set ::env(VERILOG_FILES) "\
-	$::env(CARAVEL_ROOT)/verilog/rtl/defines.v \
+	$::env(DESIGN_DIR)/../../verilog/rtl/defines.v \
 	$::env(DESIGN_DIR)/../../verilog/rtl/user_proj_example.v"
 
 set ::env(DESIGN_IS_CORE) 0

--- a/openlane/user_project_wrapper/config.tcl
+++ b/openlane/user_project_wrapper/config.tcl
@@ -36,7 +36,7 @@ set ::env(VERILOG_FILES) "\
 set ::env(CLOCK_PORT) "user_clock2"
 set ::env(CLOCK_NET) "mprj.clk"
 
-set ::env(CLOCK_PERIOD) "10"
+set ::env(CLOCK_PERIOD) "24"
 
 ## Internal Macros
 ### Macro PDN Connections
@@ -48,7 +48,7 @@ set ::env(MACRO_PLACEMENT_CFG) $::env(DESIGN_DIR)/macro.cfg
 
 ### Black-box verilog and views
 set ::env(VERILOG_FILES_BLACKBOX) "\
-	$::env(CARAVEL_ROOT)/verilog/rtl/defines.v \
+	$::env(DESIGN_DIR)/../../verilog/rtl/defines.v \
 	$::env(DESIGN_DIR)/../../verilog/rtl/user_proj_example.v"
 
 set ::env(EXTRA_LEFS) "\


### PR DESCRIPTION
- `defines.v` path was pointing to `CARAVEL_ROOT` while it should be pointing to `defines.v` in `caravel_user_project`
- `CLOCK_PERIOD` in `user_project_wrapper` was inconsistent with the one in `user_proj_example` which won't do any issues in this specific case as there is no CTS done in the wrapper, but should be corrected for consistency