### PR TITLE
Makefile: timing-root: don't always create dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ export PROJECT_ROOT=$(CUP_ROOT)
 timing-scripts-repo=https://github.com/efabless/timing-scripts.git
 
 $(TIMING_ROOT):
-	@mkdir -p $(CUP_ROOT)/dependencies
+	@mkdir -p $(TIMING_ROOT)
 	@git clone $(timing-scripts-repo) $(TIMING_ROOT)
 
 .PHONY: setup-timing-scripts


### PR DESCRIPTION
Don't always create the `dependencies/` directory, because the `TIMING_ROOT` may not be in the current project.

Instead, create the `TIMING_ROOT` directory. If this does not exist, then the `mkdir` will succeed. If it does exist, then this target will not get run.

`git` will clone into an empty directory, so for most users this will not change the flow at all.

This change prevents an empty `dependencies` directory from getting created as part of `make setup`.