### PR TITLE
Fix cocotb counter test log names

### DIFF
--- a/verilog/dv/cocotb/counter_tests/counter_la/counter_la.py
+++ b/verilog/dv/cocotb/counter_tests/counter_la/counter_la.py
@@ -7,7 +7,7 @@ import cocotb
 async def counter_la(dut):
     caravelEnv = await test_configure(dut,timeout_cycles=1346140)
 
-    cocotb.log.info(f"[TEST] Start counter_wb test")  
+    cocotb.log.info(f"[TEST] Start counter_la test")  
     # wait for start of sending
     await caravelEnv.release_csb()
     await caravelEnv.wait_mgmt_gpio(1)


### PR DESCRIPTION
I noticed that the log messages for the start of some of the counter tests were incorrect. I have changed them to the proper log messages.