### PR TITLE
Update openlane version

### DIFF
--- a/openlane/Makefile
+++ b/openlane/Makefile
@@ -16,7 +16,7 @@
 MAKEFLAGS+=--warn-undefined-variables
 
 export OPENLANE_RUN_TAG = $(shell date '+%y_%m_%d_%H_%M')
-OPENLANE_TAG ?= 2023.07.19
+OPENLANE_TAG ?= 2023.07.19-1
 OPENLANE_IMAGE_NAME ?= efabless/openlane:$(OPENLANE_TAG)
 designs = $(shell find * -maxdepth 0 -type d)
 current_design = null


### PR DESCRIPTION
The new tag has these patches applied to it https://github.com/The-OpenROAD-Project/OpenLane/pull/2037 and https://github.com/The-OpenROAD-Project/OpenLane/commit/30ee1388932eb55a89ad84ee43997bfe3a386421 (to fix pip install failure)