### PR TITLE
Remove default_nettype statements at the end of the RTL

### DIFF
--- a/verilog/rtl/user_proj_example.v
+++ b/verilog/rtl/user_proj_example.v
@@ -153,4 +153,3 @@ module counter #(
     end
 
 endmodule
-`default_nettype wire

--- a/verilog/rtl/user_project_wrapper.v
+++ b/verilog/rtl/user_project_wrapper.v
@@ -119,5 +119,3 @@ user_proj_example mprj (
 );
 
 endmodule	// user_project_wrapper
-
-`default_nettype wire


### PR DESCRIPTION
Surfaced by https://github.com/The-OpenROAD-Project/OpenLane/issues/2083. Yosys would use the `default nettype wire` when compiling the user project. Although this might be ambiguity in yosys behavior, I don't see the need of adding these lines. Having said that, there presence in the RTL seems to be intentional, I added @marwaneltoukhy and @M0stafaRady as reviewers to asses if this PR is going to have any further impact.    