### PR TITLE
Fix counter_wb test & Makefile cocotb-verify-* regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.gtkw
 /env
 /venv
+/venv-cocotb
 /caravel
 /dependencies
 /mgmt_core_wrapper

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ $(blocks): % :
 	$(MAKE) -C openlane $*
 
 dv_patterns=$(shell cd verilog/dv && find * -maxdepth 0 -type d)
-cocotb-dv_patterns=$(shell cd verilog/dv/cocotb && find . -name "*.c"  | sed -e 's|^.*/||' -e 's/.c//')
+cocotb-dv_patterns=$(shell cd verilog/dv/cocotb && find . -name "*.c"  | sed -e 's|^.*/||' -e 's/\.c//')
 dv-targets-rtl=$(dv_patterns:%=verify-%-rtl)
 cocotb-dv-targets-rtl=$(cocotb-dv_patterns:%=cocotb-verify-%-rtl)
 dv-targets-gl=$(dv_patterns:%=verify-%-gl)

--- a/verilog/dv/cocotb/user_proj_tests/counter_wb/counter_wb.py
+++ b/verilog/dv/cocotb/user_proj_tests/counter_wb/counter_wb.py
@@ -19,45 +19,54 @@ from caravel_cocotb.caravel_interfaces import test_configure
 from caravel_cocotb.caravel_interfaces import report_test
 import cocotb
 
+# Read the 16-bit counter value from GPIO[37:30,7:0]
+def counter_value(caravelEnv):
+    return int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2)
+
 @cocotb.test()
 @report_test
 async def counter_wb(dut):
-    caravelEnv = await test_configure(dut,timeout_cycles=22620)
+    caravelEnv = await test_configure(dut,timeout_cycles=27000)
 
-    cocotb.log.info(f"[TEST] Start counter_wb test")  
+    cocotb.log.info(f"[TEST] Start counter_wb test")
     # wait for start of sending
     await caravelEnv.release_csb()
     await caravelEnv.wait_mgmt_gpio(1)
-    cocotb.log.info(f"[TEST] finish configuration") 
-    overwrite_val = 7 # value will be written to the counter by wishbone 
+    cocotb.log.info(f"[TEST] Finished configuration")
+    overwrite_val = 7 # value will be written to the counter by wishbone (hard-coded in firmware)
     # expect value bigger than 7 
-    received_val = int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2)  
+    received_val = counter_value(caravelEnv)
     counter = received_val
     await cocotb.triggers.ClockCycles(caravelEnv.clk,1)
 
-    while True: # wait until the value 1 start counting after the initial
-        received_val = int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2)  
-        if counter == 0xFFFF: # rollover 
+    cocotb.log.info(f"[TEST] Testing Wishbone write")
+    # Track the counter expected vs. actual, until they diverge...
+    while True:
+        received_val = counter_value(caravelEnv)
+        if counter == 0xFFFF: # rollover
             counter = 0
         else: 
             counter +=1
-        if received_val != counter: 
-            if received_val == overwrite_val: 
-                counter = received_val +1
-                cocotb.log.info(f"Counter value has been overwritten by wishbone to be {received_val}")
-                while True: #wait until the wishbone writing finished and the counter start running again
-                    received_val = int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2)  
+        if received_val != counter:
+            # Counter actual has diverged from expected. Verify it was a Wishbone write...
+            if received_val == overwrite_val:
+                # Yes, new counter value matches the expected Wishbone overwrite value.
+                counter = received_val +1 # Counter's next value will increment from this new value.
+                cocotb.log.info(f"Counter value has been overwritten by Wishbone to be {received_val}")
+                while True: #wait until the Wishbone writing finished and the counter started running again
+                    received_val = counter_value(caravelEnv)
                     if counter == received_val: 
                         break
                     await cocotb.triggers.ClockCycles(caravelEnv.clk,1)
-                cocotb.log.info(f"Counter value has been overwritten by wishbone to be {received_val}")
+                cocotb.log.info(f"Counter value is now {received_val}")
                 break
             else: 
-                cocotb.log.error(f"Counter has wrong value before overwrite happened expected: {counter} received: {received_val}")
+                cocotb.log.error(f"Counter has wrong value before overwrite. Expected={counter} Received={received_val}")
         await cocotb.triggers.ClockCycles(caravelEnv.clk,1)
 
+    cocotb.log.info(f"[TEST] Testing 100 more counts")
     for i in range(100):
-        if counter != int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2) :
-            cocotb.log.error(f"Counter have wrong value expected = {counter} recieved = {int ((caravelEnv.monitor_gpio(37,30).binstr + caravelEnv.monitor_gpio(7,0).binstr ),2) }")
+        if counter != counter_value(caravelEnv):
+            cocotb.log.error(f"Counter has wrong value. Expected={counter} Received={counter_value(caravelEnv)}")
         await cocotb.triggers.ClockCycles(caravelEnv.clk,1)
         counter +=1


### PR DESCRIPTION
This PR fixes 3 things:
1. Test example "counter_wb" fails due to timeout: Timeout increased, and test tidied a little.
2. Minor error in regex for `cocotb-verify-*` in Makefile prevents running any test that ends in the letter `c`
3. `.gitignore` updated to exclude `venv-cocotb` (per #373 ).
